### PR TITLE
use python version 3.7.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: '3.7.6'
+        python-version: '3.7.x'
     
     - name: Install PIP packages
       run: |


### PR DESCRIPTION
In this way, in case GitHub upgrades the Python version on its side, it should not break GitHub Actions. So use this version method.