### PR TITLE
Remove 'U' from open mode

### DIFF
--- a/collector.py
+++ b/collector.py
@@ -4,7 +4,7 @@ import csv
 
 def get_teams(directory):
     teams = {}
-    fin = open(directory + "/teams.csv", 'rU')
+    fin = open(directory + "/teams.csv", 'r')
     reader = csv.DictReader(fin)
     for row in reader:
         teams[int(row['id'])] = row['name']
@@ -14,7 +14,7 @@ def get_teams(directory):
 def get_fixtures(directory):
     fixtures_home = {}
     fixtures_away = {}
-    fin = open(directory + "/fixtures.csv", 'rU')
+    fin = open(directory + "/fixtures.csv", 'r')
     reader = csv.DictReader(fin)
     for row in reader:
         fixtures_home[int(row['id'])] = int(row['team_h'])
@@ -26,7 +26,7 @@ def get_positions(directory):
     positions = {}
     names = {}
     pos_dict = {'1': "GK", '2': "DEF", '3': "MID", '4': "FWD"}
-    fin = open(directory + "/players_raw.csv", 'rU',encoding="utf-8")
+    fin = open(directory + "/players_raw.csv", 'r',encoding="utf-8")
     reader = csv.DictReader(fin)
     for row in reader:
         positions[int(row['id'])] = pos_dict[row['element_type']] 
@@ -36,7 +36,7 @@ def get_positions(directory):
 def get_expected_points(gw, directory):
     xPoints = {}
     try:
-        fin = open(os.path.join(directory, 'xP' + str(gw) + '.csv'), 'rU')
+        fin = open(os.path.join(directory, 'xP' + str(gw) + '.csv'), 'r')
         reader = csv.DictReader(fin)
         for row in reader:
             xPoints[int(row['id'])] = row['xP']
@@ -48,7 +48,7 @@ def merge_gw(gw, gw_directory):
     merged_gw_filename = "merged_gw.csv"
     gw_filename = "gw" + str(gw) + ".csv"
     gw_path = os.path.join(gw_directory, gw_filename)
-    fin = open(gw_path, 'rU', encoding="utf-8")
+    fin = open(gw_path, 'r', encoding="utf-8")
     reader = csv.DictReader(fin)
     fieldnames = reader.fieldnames
     fieldnames += ["GW"]
@@ -76,7 +76,7 @@ def collect_gw(gw, directory_name, output_dir, root_directory_name="data/2022-23
         for fname in files:
             if fname == 'gw.csv':
                 fpath = os.path.join(root, fname)
-                fin = open(fpath, 'rU')
+                fin = open(fpath, 'r')
                 reader = csv.DictReader(fin)
                 fieldnames = reader.fieldnames
                 for row in reader:


### PR DESCRIPTION
This is a minor change for compatibility with Python 3.11. The PR removes 'U' from the mode argument in "open" function calls. The 'U' mode has no effect in Python 3, and this option was removed in Python 3.11, so that existing functions in collector.py no longer work.