### PR TITLE
Adding guidlines on accessing the data directly in python

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@ The data folder contains the data from past seasons as well as the current seaso
 + season/players/player_name/gws.csv : GW-by-GW stats for that specific player
 + season/players/player_name/history.csv : Prior seasons history stats for that specific player.
 
+### Accessing the Data Directly in Python
+
+You can access data files within this repository programmatically using Python and the `pandas` library. Below is an example using the `data/2023-24/gws/merged_gw.csv` file. Similar methods can be applied to other data files in the repository. Note this is using the raw URL for direct file access, bypassing the GitHub UI.
+
+```python
+import pandas as pd
+
+# URL of the CSV file (example)
+url = "https://raw.githubusercontent.com/vaastav/Fantasy-Premier-League/master/data/2023-24/gws/merged_gw.csv"
+
+# Read the CSV file into a pandas DataFrame
+df = pd.read_csv(url)
+```
+
 ### Player Position Data
 
 In players_raw.csv, element_type is the field that corresponds to the position.


### PR DESCRIPTION
I've added into the readme some guidelines on downloading the CSVs directly in python. As opposed to cloning or downloading the whole repo.

I think this will be beneficial for those doing exploratory data analysis or using just some of the aggregated data.

Love this repo @vaastav. Thank you for putting it together. I'm looking at using it in a project so I will ensure to link to this when it's done.

