### PR TITLE
Update for 23-24 season and run global merger

### DIFF
--- a/data/master_team_list.csv
+++ b/data/master_team_list.csv
@@ -139,3 +139,23 @@ season,team,team_name
 2022-23,18,Spurs
 2022-23,19,West Ham
 2022-23,20,Wolves
+2023-24,1,Arsenal
+2023-24,2,Aston Villa
+2023-24,3,Bournemouth
+2023-24,4,Brentford
+2023-24,5,Brighton
+2023-24,6,Burnley
+2023-24,7,Chelsea
+2023-24,8,Crystal Palace
+2023-24,9,Everton
+2023-24,10,Fulham
+2023-24,11,Liverpool
+2023-24,12,Luton
+2023-24,13,Man City
+2023-24,14,Man Utd
+2023-24,15,Newcastle
+2023-24,16,Nott'm Forest
+2023-24,17,Sheffield Utd
+2023-24,18,Spurs
+2023-24,19,West Ham
+2023-24,20,Wolves

--- a/global_merger.py
+++ b/global_merger.py
@@ -3,8 +3,8 @@ from mergers import *
 def merge_data():
     """ Merge all the data and export to a new file
     """
-    season_latin = ['2016-17', '2017-18', '2018-19', '2019-20', '2020-21', '2021-22', '2022-23'] 
-    encoding_latin = ['latin-1', 'latin-1', 'latin-1', 'utf-8', 'utf-8', 'utf-8', 'utf-8']
+    season_latin = ['2016-17', '2017-18', '2018-19', '2019-20', '2020-21', '2021-22', '2022-23', '2023-24'] 
+    encoding_latin = ['latin-1', 'latin-1', 'latin-1', 'utf-8', 'utf-8', 'utf-8', 'utf-8', 'utf-8']
 
     dfs = []
     for i,j in zip(season_latin, encoding_latin):

--- a/mergers.py
+++ b/mergers.py
@@ -1,6 +1,4 @@
-from numpy.lib.index_tricks import _diag_indices_from
 import pandas as pd 
-import numpy as np
 from os.path import dirname, join
 import os
 


### PR DESCRIPTION
- updates the master_team_list
- updates the global_merger script with encoding for 23/24 season
- removes some unused imports from `mergers.py` (the `numpy.lib.index_tricks` causes an error on my machine as well)
- runs `global_merger` and updates the data file