### PR TITLE
Add manager type for new chip.

### DIFF
--- a/cleaners.py
+++ b/cleaners.py
@@ -25,6 +25,8 @@ def clean_players(filename, base_filename):
             line['element_type'] = 'MID'
         elif line['element_type'] == '4':
             line['element_type'] = 'FWD'
+        elif line['element_type'] == '5':
+            line['element_type'] = 'MGR'
         else:
             print("Oh boy")
         writer.writerow(line)

--- a/collector.py
+++ b/collector.py
@@ -25,7 +25,7 @@ def get_fixtures(directory):
 def get_positions(directory):
     positions = {}
     names = {}
-    pos_dict = {'1': "GK", '2': "DEF", '3': "MID", '4': "FWD"}
+    pos_dict = {'1': "GK", '2': "DEF", '3': "MID", '4': "FWD", '5': "MGR"}
     fin = open(directory + "/players_raw.csv", 'r',encoding="utf-8")
     reader = csv.DictReader(fin)
     for row in reader:


### PR DESCRIPTION
This is a quick fix to allow the global_scraper script to run again, but it would be good to do something more with the data.