### PR TITLE
docs: add caveat about xP scraping timing and potential lookahead

### DIFF
--- a/DATA_DICTIONARY.md
+++ b/DATA_DICTIONARY.md
@@ -296,13 +296,22 @@ Individual gameweek performance data for all players.
 
 | Column | Type | Description |
 |--------|------|-------------|
-| `xP` | float | Expected points (predicted before match) |
+| `xP` | float | Expected points from the FPL API's `ep_this` field — **see caveat below** |
 | `value` | int | Player price at this gameweek (in £0.1m) |
 | `selected` | int | Number of managers who owned this player |
 | `transfers_in` | int | Transfers in this GW |
 | `transfers_out` | int | Transfers out this GW |
 | `transfers_balance` | int | Net transfers (in - out) |
 | `modified` | bool | Whether data was modified/corrected |
+
+> **Caveat on `xP` (timing uncertainty):** `xP` is scraped from FPL's `ep_this`
+> field *after* each gameweek has ended. FPL's update cadence for this field is
+> not documented, and empirical evidence suggests scraped values may reflect
+> post-match information rather than the pre-match prediction managers actually
+> saw before the deadline. If you are using `xP` as an ML feature, treat it as
+> potentially post-match (apply `shift(1)` within each `element` group, or drop
+> the column). See the "Known Data Limitations" / "xP column" section of the
+> README before relying on it.
 
 ### Defensive Stats (when available)
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,20 @@ In players_raw.csv, element_type is the field that corresponds to the position.
 
 + GW35 expected points data is wrong (all values are 0).
 
+### `xP` column — potential lookahead for ML models
+
+The `xP` column in `gws/merged_gw.csv` is sourced from the FPL bootstrap-static API's `ep_this` field. The scraper runs **after** each gameweek ends, so if FPL updates `ep_this` post-match, the scraped value will contain information that was not available to managers before the deadline. FPL's update cadence for `ep_this` is not documented, so the exact behaviour is uncertain.
+
+Empirical comparisons suggest the scraped `xP` values diverge from live pre-match `ep_this`:
+
++ Live API `ep_this` vs `form` correlation (fetched pre-deadline): ~0.98
++ Scraped `xP` vs `form` correlation (this dataset): ~0.75
++ `xP` rolling-3 vs same-GW `total_points` correlation: ~0.40 (unusually high for a genuinely pre-match feature)
+
+**If you are training ML models on this dataset:** treat `xP` as potentially post-match. Either apply `shift(1)` within each `element` group, or exclude the column entirely. Using it unshifted as a feature to predict same-GW `total_points` has been observed to cause severe lookahead bias.
+
+See [this analysis](https://github.com/ADnocap/FPL-RL/blob/main/XP_LOOKAHEAD_ANALYSIS.md) for the full investigation.
+
 ### Contributing
 
 + If you feel like there is some data that is missing which you would like to see, then please feel free to create a PR or create an issue highlighting what is missing and what you would like to be added


### PR DESCRIPTION
Hi Vaastav,

Following up from our email thread — here's the caveat you asked for.

## What this PR adds
- A short "`xP` column — potential lookahead for ML models" section in the README (under FAQ, after Errata)
- A caveat blockquote in DATA_DICTIONARY.md on the `xP` row

## Why
The scraper runs post-GW, and empirical evidence shows the scraped `xP` values diverge from live pre-match `ep_this`:

- Live API `ep_this` vs `form` correlation (fetched pre-deadline): ~0.98
- Scraped `xP` vs `form` correlation (this dataset): ~0.75
- `xP` rolling-3 vs same-GW `total_points` correlation: ~0.40

Treating `xP` as unshifted pre-match data leads to severe lookahead when training ML models on same-GW outcomes.

Full analysis (12 statistical tests, case studies, cross-season evidence): https://github.com/ADnocap/FPL-RL/blob/main/XP_LOOKAHEAD_ANALYSIS.md

## What this PR does NOT do
This is docs-only — no changes to the scraper or data. The aim is to flag the uncertainty so ML users know to shift or drop the column.

Thanks again for maintaining this dataset — it's an incredible resource.