### PR TITLE
docs: correct xP caveat — pre-match by API design, not post-match (follow-up to #222)

### DIFF
--- a/DATA_DICTIONARY.md
+++ b/DATA_DICTIONARY.md
@@ -296,22 +296,13 @@ Individual gameweek performance data for all players.
 
 | Column | Type | Description |
 |--------|------|-------------|
-| `xP` | float | Expected points from the FPL API's `ep_this` field — **see caveat below** |
+| `xP` | float | Pre-match expected points from the FPL API's `ep_this` field, captured during the GW's `is_current=True` window. Zero/missing when the scraper missed the window (see README). |
 | `value` | int | Player price at this gameweek (in £0.1m) |
 | `selected` | int | Number of managers who owned this player |
 | `transfers_in` | int | Transfers in this GW |
 | `transfers_out` | int | Transfers out this GW |
 | `transfers_balance` | int | Net transfers (in - out) |
 | `modified` | bool | Whether data was modified/corrected |
-
-> **Caveat on `xP` (timing uncertainty):** `xP` is scraped from FPL's `ep_this`
-> field *after* each gameweek has ended. FPL's update cadence for this field is
-> not documented, and empirical evidence suggests scraped values may reflect
-> post-match information rather than the pre-match prediction managers actually
-> saw before the deadline. If you are using `xP` as an ML feature, treat it as
-> potentially post-match (apply `shift(1)` within each `element` group, or drop
-> the column). See the "Known Data Limitations" / "xP column" section of the
-> README before relying on it.
 
 ### Defensive Stats (when available)
 

--- a/README.md
+++ b/README.md
@@ -84,19 +84,13 @@ In players_raw.csv, element_type is the field that corresponds to the position.
 
 + GW35 expected points data is wrong (all values are 0).
 
-### `xP` column — potential lookahead for ML models
+### `xP` column — scraping window caveat
 
-The `xP` column in `gws/merged_gw.csv` is sourced from the FPL bootstrap-static API's `ep_this` field. The scraper runs **after** each gameweek ends, so if FPL updates `ep_this` post-match, the scraped value will contain information that was not available to managers before the deadline. FPL's update cadence for `ep_this` is not documented, so the exact behaviour is uncertain.
+`xP` is scraped from the FPL API's `ep_this` field, which is a pre-match prediction computed at each gameweek's deadline and frozen (unchanged) until the next deadline. When the scraper is run inside a gameweek's `is_current=True` window, the captured value is the correct pre-match prediction for that gameweek — it contains no post-match information.
 
-Empirical comparisons suggest the scraped `xP` values diverge from live pre-match `ep_this`:
+If the scraper misses that window entirely, `xP{N}.csv` is not written and `merged_gw.csv`'s `xP` column will be zero/empty for that gameweek. Known missing gameweeks: 2024-25 GW22, GW32, GW34. When using `xP` as an ML feature, detect these gaps (e.g. `df.groupby('GW').xP.sum() == 0`) and handle them explicitly. Also deduplicate double-gameweek rows before aggregating — `ep_this` is a single value that gets stamped on every fixture row, so use `.first()` or `.max()`, not `.sum()`.
 
-+ Live API `ep_this` vs `form` correlation (fetched pre-deadline): ~0.98
-+ Scraped `xP` vs `form` correlation (this dataset): ~0.75
-+ `xP` rolling-3 vs same-GW `total_points` correlation: ~0.40 (unusually high for a genuinely pre-match feature)
-
-**If you are training ML models on this dataset:** treat `xP` as potentially post-match. Either apply `shift(1)` within each `element` group, or exclude the column entirely. Using it unshifted as a feature to predict same-GW `total_points` has been observed to cause severe lookahead bias.
-
-See [this analysis](https://github.com/ADnocap/FPL-RL/blob/main/XP_LOOKAHEAD_ANALYSIS.md) for the full investigation.
+See [this analysis](https://github.com/ADnocap/FPL-RL/blob/main/EP_FORMULA.md) for the full investigation, including the structural proof that post-match leakage is not possible and the empirical mid-GW test that confirms `ep_this` is frozen at the deadline.
 
 ### Contributing
 


### PR DESCRIPTION
## TL;DR

Follow-up to #222. After direct investigation of FPL's `ep_this` field, the `global_scraper.py` source, and a live mid-gameweek test, the post-match lookahead concern described in #222 does not hold up. The `xP` column in `merged_gw.csv` **cannot** contain post-match information about the gameweek it labels — it is a pre-match prediction captured via the official FPL API during that gameweek's `is_current=True` window. The only known failure mode produces **missing** values, not **leaked** values.

This PR reverts the README section and the DATA_DICTIONARY blockquote added in #222, and replaces them with a shorter, accurate caveat describing the real operational issue (scraper missing the window) plus the DGW double-counting gotcha that actually does need handling.

**Disclosure:** #222 was opened by [@RubenLewis003](https://github.com/RubenLewis003). After I re-ran the investigation end-to-end, we agreed the original framing was wrong. Opening this PR from my own account to correct it.

Full write-up with lifecycle diagrams, back-solved form values, and reproducible scripts:
**→ [EP_FORMULA.md in ADnocap/FPL-RL](https://github.com/ADnocap/FPL-RL/blob/main/EP_FORMULA.md)**

---

## Why #222's framing is incorrect

### 1. Structural — the API has no post-match slot for `ep_this`

`bootstrap-static` returns each player as a single JSON object with **one** `ep_this` scalar. There is no `ep_history`, no per-GW array. That scalar is computed at the GW deadline from pre-match inputs (form, team/opponent strength, `chance_of_playing_this_round`), stored, and then overwritten at the **next** deadline when `is_current` flips to GW N+1. Between the two deadlines — including across `finished=True` — the value is immutable. FPL would have to actively rewrite the live scalar for a post-match value to appear in it.

### 2. The scraper cannot mis-label

`global_scraper.py` reads `ep_this` for every player **and** the `is_current=True` event id from the same `get_data()` call. Label and values come from one atomic snapshot:

~~~python
data = get_data()                                # single API call

xPoints = []
for e in data["elements"]:
    xPoints.append({'id': e['id'], 'xP': e['ep_this']})  # values

gw_num = 0
for event in data["events"]:
    if event["is_current"] == True:
        gw_num = event["id"]                     # label

if gw_num > 0:
    write(f'xP{gw_num}.csv', xPoints)            # label and values bound together
~~~

It is mechanically impossible to produce an `xP{N}.csv` whose values correspond to anything other than what `is_current` was pointing at in that snapshot. The only real failure mode is *not running the scraper during GW N's `is_current=True` window*, which produces a **missing file** — the three zero-xP GWs in 2024-25 (22, 32, 34) are exactly this: gaps, not leaks.

### 3. Empirical proof — live API caught mid-GW33 (2026-04-21)

GW33 deadline was 2026-04-18 10:00 UTC. By 2026-04-21, 10/13 fixtures had finished; `form` had updated on the API for every player whose team had played. If `ep_this` were dynamic, it would reflect the new form. Back-solving the published formula (`ep_this = round((form + offset) × cop/100, 1)`) recovers the form value **as it was at the deadline**, not the current form:

| Player | GW33 opp | offset | form_now | ep_this (API) | form_deadline (back-solved) | Δ form | ep_this if dynamic |
|---|---|---|---|---|---|---|---|
| Son (Spurs) | Brighton | 0 | 6.0 | **3.5** | 3.5 | +2.5 | 6.0 ≠ 3.5 |
| Rashford (Man Utd) | Chelsea | 0 | 5.5 | **3.0** | 3.0 | +2.5 | 5.5 ≠ 3.0 |
| Salah (Liverpool) | Everton | +0.5 | 5.0 | **3.5** | 3.0 | +2.0 | 5.5 ≠ 3.5 |
| Isak (Newcastle) | Bournemouth | 0 | 4.5 | **2.5** | 2.5 | +2.0 | 4.5 ≠ 2.5 |
| Haaland (Man City) | Arsenal | -0.5 | 8.0 | **5.0** | 5.5 | +2.5 | 7.5 ≠ 5.0 |

`ep_this` moved by 0.0 in every case while `form` moved by +2.0 to +2.5. Only possible if `ep_this` is a stored scalar set at the deadline.

Bonus case: Man City's GW33 became a DGW *after* the deadline when a second fixture vs Burnley was added. Haaland's `ep_this = 5.0` still matches a single-fixture computation against the GW33 deadline-time form, ignoring both his 22-point haul and the newly-added fixture. Frozen in every dimension.

### 4. The correlation figures in #222 are inflated by non-playing filler

#222 cited:

- `corr(xP, form)` ≈ 0.75 in the dataset (vs ~0.98 live pre-deadline)
- `corr(xP_rolling_3, total_points)` ≈ 0.40

Both are inflated by the ~60% of `merged_gw.csv` rows belonging to players who never play in a given GW — reserves, u21s, injured, squad filler. Every such row contributes a `(0, 0)` pair that raises correlation without carrying predictive content.

Computed on the 2024-25 `merged_gw.csv` (DGW-deduplicated, 3 missing-xP GWs excluded):

| Filter | N | corr(xP, total_points) |
|---|---|---|
| All players | 25,059 | **0.72** |
| Played (min > 0) | 10,565 | **0.59** |
| Started (min ≥ 60) | 7,144 | **0.55** |
| Expected to start (xP ≥ 2) | 6,218 | **0.47** |

A post-match leak would push correlation toward 1.0 for players who played. The correlation **dropping by a third** when you filter to played rows is exactly the opposite signal. Two sharper tests:

- **Blanked starters** (xP ≥ 3, min ≥ 60, total_points ≤ 1): **372 rows**, mean xP = 4.1, mean actual = 0.8. A post-match signal would equal the outcome; `xP` over-predicts by 3.3 pts on average.
- **Unexpected hauls** (xP < 3, total_points ≥ 10): **17 rows**, mean xP = 2.1, mean actual = 11.2. Pre-match underestimates that a leak would have caught.

MAE between `xP` and same-GW `total_points` for players who played: **1.65 pts** — a post-match-contaminated signal would have MAE near 0.

The ~0.75 vs ~0.98 `corr(xP, form)` gap is also explained without lookahead: `form` in `merged_gw.csv` is a post-scrape snapshot reflecting form *after* that GW's matches, while `xP` was computed against deadline-time form. The 30-day rolling lag between the two quantities produces the drop. Merge artefact, not leak.

---

## What this PR changes

### `README.md` — replaces the "`xP` column — potential lookahead for ML models" section

The old section described a mechanism that cannot occur and recommended `shift(1)` or dropping the column, which is unnecessary and harmful to downstream users who follow it. Replaced with a shorter, accurate caveat documenting the real operational failure mode (missing scrape window) and the DGW double-counting gotcha.

### `DATA_DICTIONARY.md` — shortens the `xP` row

Row description now accurately says "pre-match expected points ... captured during the GW's `is_current=True` window". The 7-line "timing uncertainty" blockquote is removed; the README section covers the operational caveat.

---

## Why this matters

ML practitioners following #222's advice to `shift(1)` or drop `xP` are discarding one of the most informative pre-match features in the dataset — it encodes injuries and lineup news that no reconstructed feature can match. The original caveat was added in good faith based on indirect correlation evidence, but direct inspection of the API data model, scraper source, and live lifecycle disproves the post-match mechanism. Dataset users deserve the accurate version.

Happy to iterate on wording if anything reads too strong or you'd like the caveat positioned differently in the README.

Thanks for maintaining this dataset — it's an incredible resource.